### PR TITLE
Support for subscriber adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules
 parts
 src/senaite.core
 yarn.lock
+*.egg-info
+*.pyc

--- a/src/senaite/core/listing/ajax.py
+++ b/src/senaite/core/listing/ajax.py
@@ -15,7 +15,7 @@ from senaite.core.listing.decorators import inject_runtime
 from senaite.core.listing.decorators import returns_safe_json
 from senaite.core.listing.decorators import set_application_json_header
 from senaite.core.listing.decorators import translate
-from senaite.core.listing.interfaces import IListingView
+from senaite.core.listing.interfaces import IAjaxListingView
 from zope.interface import implements
 from zope.lifecycleevent import modified
 from zope.publisher.interfaces import IPublishTraverse
@@ -27,7 +27,7 @@ class AjaxListingView(BrowserView):
     The main purpose of this class is to provide a JSON API endpoint for the
     ReactJS based listing table.
     """
-    implements(IListingView, IPublishTraverse)
+    implements(IAjaxListingView, IPublishTraverse)
     contents_table_template = ViewPageTemplateFile(
         "templates/contents_table.pt")
 

--- a/src/senaite/core/listing/interfaces.py
+++ b/src/senaite/core/listing/interfaces.py
@@ -10,3 +10,20 @@ from zope.interface import Interface
 class IListingView(Interface):
     """Senaite Core Listing View
     """
+
+
+class IAjaxListingView(Interface):
+    """Senaite Core Ajax Listing View
+    """
+
+
+class IListingViewAdapter(Interface):
+    """Marker that allows to modify the behavior of ListingView
+    """
+    def before_render(self):
+        """Before render hook
+        """
+
+    def folder_item(self, obj, item, index):
+        """folder_item hook
+        """

--- a/src/senaite/core/listing/utils.py
+++ b/src/senaite/core/listing/utils.py
@@ -1,0 +1,82 @@
+from senaite.core.listing.interfaces import IListingView
+import collections
+
+
+def add_review_state(listing, review_state, before=None, after=None):
+    """Adds a new review state in the listing
+    """
+    if not IListingView.providedBy(listing):
+        raise ValueError("Type not supported: {}".format(repr(type(listing))))
+
+    if not review_state:
+        return False
+
+    # Do nothing if the review state is already there
+    ids = map(lambda st: st["id"], listing.review_states)
+    if review_state["id"] in ids:
+        return False
+
+    if before and before not in ids:
+        raise ValueError("Review state '{}' does not exist".format(before))
+
+    if after and after not in ids:
+        raise ValueError("Review state '{}' does not exist".format(after))
+
+    idx = len(ids)
+    if before:
+        idx = ids.index(before)
+    elif after:
+        idx = ids.index(after) + 1
+    listing.review_states.insert(idx, review_state)
+    return True
+
+
+def add_column(listing, column_id, column_values, before=None, after=None,
+               review_states=None):
+    """Adds a column to the listing
+    """
+    if not IListingView.providedBy(listing):
+        raise ValueError("Type not supported: {}".format(repr(type(listing))))
+
+    if not column_id or not column_values:
+        return False
+
+    ids = listing.columns.keys()
+    if column_id in ids:
+        listing.columns[column_id].update(column_values)
+        return True
+
+    if before and before not in ids:
+        raise ValueError("Column '{}' does not exist".format(before))
+
+    if after and after not in ids:
+        raise ValueError("Column '{}' does not exist".format(after))
+
+    new_dict = collections.OrderedDict()
+    for key, item in listing.columns.copy().items():
+        if before == key:
+            new_dict[column_id] = column_values
+        new_dict[key] = item
+        if after == key:
+            new_dict[column_id] = column_values
+    listing.columns = new_dict
+
+    if not review_states:
+        return True
+
+    new_states = []
+    for state in listing.review_states:
+        rv_state = state.copy()
+        if rv_state["id"] in review_states:
+            cols = rv_state.get("columns", [])
+            if column_id not in cols:
+                idx = len(cols)
+                if before and before in cols:
+                    idx = cols.index(before)
+                elif after and after in cols:
+                    idx = cols.index(after)
+                cols.insert(idx, column_id)
+                state["columns"] = cols
+        new_states.append(rv_state)
+    listing.review_states = new_states
+    return True

--- a/src/senaite/core/listing/utils.py
+++ b/src/senaite/core/listing/utils.py
@@ -74,7 +74,7 @@ def add_column(listing, column_id, column_values, before=None, after=None,
                 if before and before in cols:
                     idx = cols.index(before)
                 elif after and after in cols:
-                    idx = cols.index(after)
+                    idx = cols.index(after) + 1
                 cols.insert(idx, column_id)
                 state["columns"] = cols
         new_states.append(rv_state)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Note the following use-case:

- Add-on A needs to add column "DateStored" in Samples listing, along with filter/button "Stored"
- Add-on B needs to add column "Participant" in Samples listing, along with filter/button "Ordered"
- Add-on A mustn't depend on B.
- Add-on B mustn't depend on A.
- Both Add-ons installed.

There is no possible solution (maybe a workaround) for this (quite common) use-case at the moment, cause the system relies only on listing inheritance. This Pull Request allows to add multiple subscriber adapters for same listing object, so different add-ons (and even same add-on) can modify the behavior of the listing by his own. With this PR, the solution for the use-case explained above becomes simple, there's only the need to add subscribers as follows in each add-on:

```
  <!-- Samples view with additional filters and columns -->
  <subscriber
    for="senaite.core.listing.interfaces.IListingView
         bika.lims.interfaces.IAnalysisRequestsFolder"
    provides="senaite.core.listing.interfaces.IListingViewAdapter"
    factory=".analysisrequests.AnalysisRequestsListingViewAdapter" />
```

And let the `AnalysisRequestsListingViewAdapter` from each add-on deal with function `before_render` and `folder_item`.

## Current behavior before PR

Not possible to modify the behavior of a given listing by multiple add-ons without making them dependents.

## Desired behavior after PR is merged

Possible to modify the behavior of a given listing by independent add-ons

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
