### PR TITLE
Ensure subscriber adapters for ListingView are called at the end

### DIFF
--- a/src/senaite/core/listing/interfaces.py
+++ b/src/senaite/core/listing/interfaces.py
@@ -20,6 +20,13 @@ class IAjaxListingView(Interface):
 class IListingViewAdapter(Interface):
     """Marker that allows to modify the behavior of ListingView
     """
+
+    def get_priority_order(self):
+        """Returns an number that represents the order of priority of this
+        adapter over other subscriber adapters that adapt same context and
+        listing view. A lower value means more priority.
+        """
+
     def before_render(self):
         """Before render hook
         """

--- a/src/senaite/core/listing/view.py
+++ b/src/senaite/core/listing/view.py
@@ -226,7 +226,8 @@ class ListingView(AjaxListingView):
         # different add-ons to be able to modify columns, etc. without
         # dependencies amongst them.
         adapters = subscribers((self, self.context), IListingViewAdapter)
-        return sorted(adapters, key=lambda ad: float(ad.get_priority_order()))
+        return sorted(adapters, key=lambda ad: api.to_float(
+            ad.get_priority_order(), 0))
 
     def contents_table(self, *args, **kwargs):
         """Render the ReactJS enabled contents table template

--- a/src/senaite/core/listing/view.py
+++ b/src/senaite/core/listing/view.py
@@ -218,13 +218,15 @@ class ListingView(AjaxListingView):
             subscriber.before_render()
 
     def get_listing_view_adapters(self):
-        """Returns subscriber adapters used to modify the listing behavior
+        """Returns subscriber adapters used to modify the listing behavior,
+        sorted from higher to lower priority
         """
         # Allows to override this listing by multiple subscribers without the
         # need of inheritance. We use subscriber adapters here because we need
         # different add-ons to be able to modify columns, etc. without
         # dependencies amongst them.
-        return subscribers((self, self.context), IListingViewAdapter)
+        adapters = subscribers((self, self.context), IListingViewAdapter)
+        return sorted(adapters, key=lambda ad: float(ad.get_priority_order()))
 
     def contents_table(self, *args, **kwargs):
         """Render the ReactJS enabled contents table template
@@ -742,8 +744,6 @@ class ListingView(AjaxListingView):
             the template
         :index: current index of the item
         """
-        for subscriber in self.get_listing_view_adapters():
-            subscriber.folder_item(obj, item, index)
         return item
 
     def folderitems(self, full_objects=False, classic=True):
@@ -870,6 +870,11 @@ class ListingView(AjaxListingView):
             # service. folderitem service is frequently overriden by child
             # objects
             item = self.folderitem(obj, results_dict, idx)
+
+            # Call folder_item from subscriber adapters
+            for subscriber in self.get_listing_view_adapters():
+                subscriber.folder_item(obj, item, idx)
+
             if item:
                 results.append(item)
                 idx += 1
@@ -1069,6 +1074,11 @@ class ListingView(AjaxListingView):
             # service. folderitem service is frequently overriden by child
             # objects
             item = self.folderitem(obj, results_dict, idx)
+
+            # Call folder_item from subscriber adapters
+            for subscriber in self.get_listing_view_adapters():
+                subscriber.folder_item(obj, item, idx)
+
             if item:
                 results.append(item)
                 idx += 1


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Supersedes https://github.com/senaite/senaite.core/pull/1247**

With this Pull Request, the calls to `folder_item` from subscriber adapters are always done after the `folderitem` function from the listing view itself is called. This is necessary to ensure the adapters have the items populated correctly with the information provided by AR lsiting before taking any action.

It also adds the signature `get_priority_order` to subscriber adapters, so when there are multiple adapters for same listing view and context, adapters with a lower value for `get_priority_order` are called first.

## Current behavior before PR

Subscriber adapters are called before logic of function `folderitems` from ListingView view takes place.

## Desired behavior after PR is merged

Subscriber adapters are called after logic of function `folderitems` from ListingView takes place.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
