### PR TITLE
Make priority_order optional and set 1000 as default

### DIFF
--- a/src/senaite/core/listing/interfaces.py
+++ b/src/senaite/core/listing/interfaces.py
@@ -21,12 +21,6 @@ class IListingViewAdapter(Interface):
     """Marker that allows to modify the behavior of ListingView
     """
 
-    def get_priority_order(self):
-        """Returns an number that represents the order of priority of this
-        adapter over other subscriber adapters that adapt same context and
-        listing view. A lower value means more priority.
-        """
-
     def before_render(self):
         """Before render hook
         """

--- a/src/senaite/core/listing/view.py
+++ b/src/senaite/core/listing/view.py
@@ -217,6 +217,7 @@ class ListingView(AjaxListingView):
                 subscriber.__module__, subscriber.__class__.__name__))
             subscriber.before_render()
 
+    @view.memoize
     def get_listing_view_adapters(self):
         """Returns subscriber adapters used to modify the listing behavior,
         sorted from higher to lower priority
@@ -227,7 +228,7 @@ class ListingView(AjaxListingView):
         # dependencies amongst them.
         adapters = subscribers((self, self.context), IListingViewAdapter)
         return sorted(adapters, key=lambda ad: api.to_float(
-            ad.get_priority_order(), 0))
+            getattr(ad, "priority_order", 1000)))
 
     def contents_table(self, *args, **kwargs):
         """Render the ReactJS enabled contents table template


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

It makes https://github.com/senaite/senaite.core.listing/pull/3 a bit simpler

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
