### PR TITLE
Improved replace_url column handler

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.0.1 (unreleased)
 ------------------
 
+- #10 Improved replace_url column handler
 - #9 Show status messages on API errors
 - #9 Only fetch affected folderitems by UID after a field was updated
 - #7 Hide comment toggle in transposed cell when remarks are disabled


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves the handler for `replace_url`, e.g. for the Client column in the samples listing:

```
            ("Client", {
                "title": _("Client"),
                "index": "getClientTitle",
                "attr": "getClientTitle",
                "replace_url": "getClientURL",
                "toggle": True}),
```

## Current behavior before PR

Absolute URLs starting with `/` are used, which breaks the linkage on non VHM sites

## Desired behavior after PR is merged

The absolute URL of the portal is prepended to URLs starting with `/`

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
