### PR TITLE
Notify edited event on set fields

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 1.2.0 (unreleased)
 ------------------
 
-- no changes yet
+- #11 Notify edited event on set fields
 
 
 1.1.0 (2019-03-30)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR notifies the `ObjectEditedEvent` for all updated objects when the "Save" Button was clicked.

With this change the Audit Log will show a new version for each Ajax Save.

## Current behavior before PR

Changes in the listing were not reflected in the Audit-Log

## Desired behavior after PR is merged

Changes show up in the Audit Log on Save

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
