### PR TITLE
Fix Partitions are not displayed when "Published" filter is used

### DIFF
--- a/src/senaite/core/listing/view.py
+++ b/src/senaite/core/listing/view.py
@@ -557,6 +557,12 @@ class ListingView(AjaxListingView):
         # avoid to change the original content filter
         query = copy.deepcopy(self.contentFilter)
 
+        # Skip all further processing if explicit UIDs are requested.
+        # This is required to render child-nodes properly.
+        # https://github.com/senaite/senaite.impress/issues/70
+        if "UID" in query:
+            return query
+
         # contentFilter is allowed in every self.review_state.
         for k, v in self.review_state.get("contentFilter", {}).items():
             query[k] = v

--- a/src/senaite/core/listing/view.py
+++ b/src/senaite/core/listing/view.py
@@ -559,7 +559,7 @@ class ListingView(AjaxListingView):
 
         # Skip all further processing if explicit UIDs are requested.
         # This is required to render child-nodes properly.
-        # https://github.com/senaite/senaite.impress/issues/70
+        # https://github.com/senaite/senaite.core.listing/issues/12
         if "UID" in query:
             return query
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the filtering of child nodes as described in https://github.com/senaite/senaite.core.listing/issues/12

## Current behavior before PR

Child nodes where filtered in certain states

## Desired behavior after PR is merged

Child nodes are displayed always and independent of their state

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
