### PR TITLE
Convert URLs/Paths to absolute URLs

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.2.0 (unreleased)
 ------------------
 
+- #14 Convert URLs/Paths to absolute URLs
 - #11 Notify edited event on set fields
 
 

--- a/src/senaite/core/listing/view.py
+++ b/src/senaite/core/listing/view.py
@@ -890,8 +890,9 @@ class ListingView(AjaxListingView):
                 if replace_url:
                     attrobj = getFromString(obj, replace_url)
                     if attrobj:
+                        url = self.url_or_path_to_url(attrobj)
                         results_dict['replace'][key] = \
-                            '<a href="%s">%s</a>' % (attrobj, value)
+                            '<a href="%s">%s</a>' % (url, value)
             # The item basics filled. Delegate additional actions to folderitem
             # service. folderitem service is frequently overriden by child
             # objects
@@ -1093,8 +1094,9 @@ class ListingView(AjaxListingView):
                 if replace_url:
                     attrobj = getFromString(obj, replace_url)
                     if attrobj:
+                        url = self.url_or_path_to_url(attrobj)
                         results_dict['replace'][key] = \
-                            '<a href="%s">%s</a>' % (attrobj, value)
+                            '<a href="%s">%s</a>' % (url, value)
 
             # The item basics filled. Delegate additional actions to folderitem
             # service. folderitem service is frequently overriden by child
@@ -1110,3 +1112,28 @@ class ListingView(AjaxListingView):
                 idx += 1
 
         return results
+
+    @view.memoize
+    def url_or_path_to_url(self, url_or_path):
+        """Convert a given URL or path to an absolute URL
+
+        N.B. This method might receive paths from brain metadata.
+        These paths might or might not be rooted at the portal path.
+
+        :param url_or_path: Absolute URL, physical path or relative path
+        :returns: Absolute URL
+        """
+        portal_path = api.get_path(self.portal)
+        portal_url = api.get_url(self.portal)
+
+        # remove the portal_url from the url_or_path
+        if url_or_path.startswith(portal_url):
+            url_or_path = url_or_path.replace(portal_url, "", 1)
+        # remove the portal_path from the url_or_path
+        if url_or_path.startswith(portal_path):
+            url_or_path = url_or_path.replace(portal_path, "", 1)
+        # remove leading "/"
+        if url_or_path.startswith("/"):
+            url_or_path = url_or_path.replace("/", "", 1)
+
+        return "/".join([portal_url, url_or_path])


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the `replace_url` columns directive to correctly convert (virtual) paths to absolute URLs.

Please note, we cannot simply prepend the portal_path at this place, because this would generate wrong links for virtual hosted sites, e.g. `http://example.com/senaite/clients/client-1`.

Specific issue:
The Client link in the samples listing was generated by the brain metadata value of `getClientURL`.
Depending if the site is running with virtual hosting, this URL might not contain the portal path, although the path starts with a `/`, e.g. `/clients/client-1`.

## Current behavior before PR

Clicking on the client URL without virtual hosting caused a 404, because the generated URL did not contain the portal path, e.g. `http://localhost:8080/clients/client-1`  

## Desired behavior after PR is merged

Clicking on the client URL without virtual hosting navigates to the client, because the generated URL 
 contains the portal path, e.g. `http://localhost:8080/senaite/clients/client-1`  


--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
