### PR TITLE
Remove classic listing mode and improve folderitems

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,3 +1,8 @@
+1.5.0 (unreleased)
+------------------
+
+- #28 Remove classic listing mode and improve folderitems
+
 1.4.0 (2020-03-01)
 ------------------
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request removes the classic listing mode for `folderitems` and improves the function as well. It also removes the retrieval of workflow states by using the metadata `getObjWorkflowStates`. This was only required when there were objects with multiple workflows attached. Objects are bound to a single workflow from long time ago, so the retrieval of the status can rely directly on review_state parameter from item

## Current behavior before PR

Confusing `classic`mode and `full_objects` parameters in `folderitems` function

## Desired behavior after PR is merged

Naive `folderitems` function, without params. `folderitem` function always receive a brain as param `obj`

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
